### PR TITLE
Don't swallow parameter after `-c`

### DIFF
--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -139,7 +139,6 @@ function parse_options() {
             -c|-C|--cacerts)
                 cacerts=true
                 verbose "Linking system CA certificates"
-                shift
                 ;;
             *)
                 script_exit "Invalid argument was provided: ${option}" 2


### PR DESCRIPTION
The `-c` flag and its aliases don't take an argument, so there should be no `shift`.