### PR TITLE
Add a error message if the download url could not be determined.

### DIFF
--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -203,7 +203,7 @@ function determine_url() {
     # EA or RC build?
     local JAVA_NET="http://jdk.java.net/${feature}"
     local candidates=$(wget --quiet --output-document - ${JAVA_NET} | grep -Eo 'href[[:space:]]*=[[:space:]]*"[^\"]+"' | grep -Eo '(http|https)://[^"]+')
-    url=$(echo "${candidates}" | grep -Eo "${DOWNLOAD}/.+/jdk${feature}/.+/${license}/.*jdk-${feature}.+${os}_bin.tar.gz$ || true")
+    url=$(echo "${candidates}" | grep -Eo "${DOWNLOAD}/.+/jdk${feature}/.+/${license}/.*jdk-${feature}.+${os}_bin.tar.gz$" || true)
 
     if [[ -z ${url} ]]; then
         script_exit "Couldn't determine a download url for ${feature}-${license} on ${os}" 1

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -23,7 +23,7 @@ set -o errexit
 
 function initialize() {
     readonly script_name="$(basename "${BASH_SOURCE[0]}")"
-    readonly script_version='2018-07-17'
+    readonly script_version='2018-08-15'
 
     dry=false
     silent=false

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -203,7 +203,11 @@ function determine_url() {
     # EA or RC build?
     local JAVA_NET="http://jdk.java.net/${feature}"
     local candidates=$(wget --quiet --output-document - ${JAVA_NET} | grep -Eo 'href[[:space:]]*=[[:space:]]*"[^\"]+"' | grep -Eo '(http|https)://[^"]+')
-    url=$(echo "${candidates}" | grep -Eo "${DOWNLOAD}/.+/jdk${feature}/.+/${license}/.*jdk-${feature}.+${os}_bin.tar.gz$")
+    url=$(echo "${candidates}" | grep -Eo "${DOWNLOAD}/.+/jdk${feature}/.+/${license}/.*jdk-${feature}.+${os}_bin.tar.gz$ || true")
+
+    if [[ -z ${url} ]]; then
+        script_exit "Couldn't determine a download url for ${feature}-${license} on ${os}" 1
+    fi
 }
 
 function prepare_variables() {


### PR DESCRIPTION
grep exits with an exit code != 0, which makes the whole script stop
immediately.
Manually checking whether the url is empty, allows to write an error
message before exiting.

E.g. `./install-jdk.sh -F 11 -L BCL -o osx-x64` currently fails silently
because there is no tar.gz file for osx available.