### PR TITLE
Reduce memory usage of java -version

### DIFF
--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -312,7 +312,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx10m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 


### PR DESCRIPTION
On big RAM machines it seems more than 1.5G is required to even run `java -version` resulting sometimes in "Not enough space"

Have set it to -Xmx10m and tested on JDK8 and 11