### PR TITLE
The current Xmx10m is not sufficient for ZGC

### DIFF
--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx32m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx100m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx50m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx100m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx100m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx32m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx10m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx30m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx200m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx100m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx30m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx200m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 

--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -310,7 +310,7 @@ function main() {
     export JAVA_HOME=$(cd "${target}"; pwd)
     export PATH=${JAVA_HOME}/bin:$PATH
 
-    if [[ ${silent} == false ]]; then java -Xmx100m -version; fi
+    if [[ ${silent} == false ]]; then java -Xmx50m -version; fi
     if [[ ${emit_java_home} == true ]]; then echo "${JAVA_HOME}"; fi
 }
 


### PR DESCRIPTION
My own change broke a build on our side ;)

So 10m is too small and 50m would be sufficient but I used 100m to have some space and avoid future problems and this is still below the default Xmx settings on travis (118m). On jdk8 you can find it out via:

```
java -XX:+PrintFlagsFinal -version | grep InitialHeapSize
```