### PR TITLE
When using the darwin tarball the JDK version is not parsed correctly

### DIFF
--- a/install-jdk.sh
+++ b/install-jdk.sh
@@ -260,7 +260,7 @@ function download_and_extract_and_set_target() {
         if [[ "$OSTYPE" != "darwin"* ]]; then
             target="${workspace}"/$(tar --list ${tar_options} | grep 'bin/javac' | tr '/' '\n' | tail -3 | head -1)
         else
-            target="${workspace}"/$(tar --list ${tar_options} | head -2 | tail -1 | cut -f 2 -d '/' -)/Contents/Home
+            target="${workspace}"/$(tar --list ${tar_options} | head -2 | tail -1 | cut -f 1 -d '/' -)/Contents/Home
         fi
         verbose "Set target to: ${target}"
     else


### PR DESCRIPTION
The `tar --list for OpenJDK11U-jdk_x64_mac_hotspot_11.0.4_11.tar.gz` starts with:
```
./._jdk-11.0.4+11
jdk-11.0.4+11/
jdk-11.0.4+11/Contents/
```

The second line is used to determine the JDK version and the incorrect field, 2, is specified in the cut command. With this PR the field, 1, is specified to obtain the correct version. Otherwise, this version of the JDK is not usable on Mac OS in travis-ci.
